### PR TITLE
Implement Snell's law and add tests

### DIFF
--- a/aberration_animation.py
+++ b/aberration_animation.py
@@ -6,33 +6,49 @@ from matplotlib.animation import FuncAnimation
 # Parameters
 n_rays = 7
 frames = 120
+n1 = 1.0  # refractive index of the medium on the left
+n2 = 1.5  # refractive index of the medium on the right
 
 # y positions for incoming rays
 ys = np.linspace(-0.4, 0.4, n_rays)
 
-# Scenario 1: rays hit a circular lens and fail to meet at a single focus
-scenario1 = []
-for y in ys:
-    start = [-1.0, y]
-    lens_point = [0.0, y]
-    # rays diverge slightly after passing through the lens
-    final = [1.2, 0.2 * y]
-    scenario1.append(np.array([start, lens_point, final]))
-scenario1 = np.array(scenario1)
+
+def generate_scenario1(ys):
+    """Rays that pass through a circular lens and fail to focus."""
+    rays = []
+    for y in ys:
+        start = [-1.0, y]
+        lens_point = [0.0, y]
+        final = [1.2, 0.2 * y]
+        rays.append(np.array([start, lens_point, final]))
+    return np.array(rays)
+
+
+def generate_scenario2(ys, plane_x, x_final=1.2, n1=n1, n2=n2):
+    """Rays refracted by a plane surface following Snell's law."""
+    rays = []
+    for y in ys:
+        start = [-1.0, y]
+        slope = -y / 2.0
+        y_plane = y + slope * (plane_x - start[0])
+        plane_point = [plane_x, y_plane]
+
+        theta1 = np.arctan(slope)
+        sin_theta2 = (n1 / n2) * np.sin(theta1)
+        theta2 = np.arcsin(sin_theta2)
+        slope2 = np.tan(theta2)
+        y_final = y_plane + slope2 * (x_final - plane_x)
+        final = [x_final, y_final]
+
+        rays.append(np.array([start, plane_point, final]))
+    return np.array(rays)
+
+
+scenario1 = generate_scenario1(ys)
 
 # Scenario 2: rays aim toward a focus but are refracted by a plane
 plane_x = 0.5
-scenario2 = []
-for y in ys:
-    start = [-1.0, y]
-    # intersection with plane assuming ideal focus at (1, 0)
-    slope = -y / 2.0
-    y_plane = y + slope * (plane_x - (-1.0))
-    plane_point = [plane_x, y_plane]
-    # after refraction, rays miss the focus
-    final = [1.2, 0.25 * y]
-    scenario2.append(np.array([start, plane_point, final]))
-scenario2 = np.array(scenario2)
+scenario2 = generate_scenario2(ys, plane_x)
 
 fig, ax = plt.subplots(figsize=(6, 4))
 ax.set_xlim(-1.2, 1.3)
@@ -74,6 +90,7 @@ def update(frame):
     return lines + [surface]
 
 
-ani = FuncAnimation(fig, update, frames=frames, interval=50, blit=True)
+if __name__ == "__main__":
+    ani = FuncAnimation(fig, update, frames=frames, interval=50, blit=True)
 
-plt.show()
+    plt.show()

--- a/tests/test_snell.py
+++ b/tests/test_snell.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import aberration_animation as aa
+
+
+def test_single_angle_change():
+    plane_x = aa.plane_x
+    for ray in aa.scenario2:
+        start, mid, end = ray
+        # angle change occurs at the surface
+        assert start[0] < plane_x < end[0]
+        assert np.isclose(mid[0], plane_x)
+        slope1 = (mid[1] - start[1]) / (mid[0] - start[0])
+        slope2 = (end[1] - mid[1]) / (end[0] - mid[0])
+        if not np.isclose(start[1], 0):
+            assert not np.isclose(slope1, slope2)
+        else:
+            # central ray passes straight through
+            assert np.isclose(slope1, 0)
+            assert np.isclose(slope2, 0)
+
+
+def test_snells_law_constant_ratio():
+    plane_x = aa.plane_x
+    ratios = []
+    for ray in aa.scenario2:
+        start, mid, end = ray
+        slope1 = (mid[1] - start[1]) / (mid[0] - start[0])
+        slope2 = (end[1] - mid[1]) / (end[0] - mid[0])
+        theta1 = np.arctan(slope1)
+        theta2 = np.arctan(slope2)
+        if np.isclose(np.sin(theta2), 0):
+            continue
+        ratios.append(np.sin(theta1) / np.sin(theta2))
+    assert ratios, "no valid rays for ratio"
+    ratio_first = ratios[0]
+    for r in ratios:
+        assert np.isclose(r, ratio_first)
+    assert np.isclose(ratio_first, aa.n2 / aa.n1)


### PR DESCRIPTION
## Summary
- refactor animation script to expose scenario generation functions
- compute refracted rays using Snell's law
- guard animation start with `if __name__ == "__main__"`
- add unit tests to verify a single angle change and constant Snell ratio

## Testing
- `pytest -q`