### PR TITLE
Add Snell law tests and helper

### DIFF
--- a/aberration_animation.py
+++ b/aberration_animation.py
@@ -3,6 +3,42 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
 
+def compute_snell_paths(
+    n_rays, plane_x=0.5, n1=1.0, n2=1.5, final_x=1.2, y_limits=(-0.4, 0.4)
+):
+    """Return ray paths obeying Snell's law for a plane surface.
+
+    Each ray starts at ``x=-1`` and intersects the plane ``x=plane_x`` before
+    being refracted. The outgoing segment is calculated so that the ratio
+    ``sin(theta_in)/sin(theta_out)`` is constant for all rays.
+    """
+
+    ys = np.linspace(y_limits[0], y_limits[1], n_rays)
+    ratio = n2 / n1
+    rays = []
+    for y in ys:
+        start = np.array([-1.0, y])
+
+        # Incoming ray heading towards the ideal focus at (1, 0)
+        slope_in = -y / 2.0
+        y_plane = y + slope_in * (plane_x - (-1.0))
+        plane_point = np.array([plane_x, y_plane])
+
+        theta_in = np.arctan2(y_plane - y, plane_x - (-1.0))
+
+        if np.isclose(theta_in, 0.0):
+            theta_out = 0.0
+        else:
+            theta_out = np.sign(theta_in) * np.arcsin(np.sin(theta_in) / ratio)
+
+        slope_out = np.tan(theta_out)
+        y_final = y_plane + slope_out * (final_x - plane_x)
+        final_point = np.array([final_x, y_final])
+
+        rays.append(np.stack([start, plane_point, final_point]))
+    return np.array(rays)
+
+
 # Parameters
 n_rays = 7
 frames = 120
@@ -20,19 +56,9 @@ for y in ys:
     scenario1.append(np.array([start, lens_point, final]))
 scenario1 = np.array(scenario1)
 
-# Scenario 2: rays aim toward a focus but are refracted by a plane
+# Scenario 2: rays are refracted by a plane obeying Snell's law
 plane_x = 0.5
-scenario2 = []
-for y in ys:
-    start = [-1.0, y]
-    # intersection with plane assuming ideal focus at (1, 0)
-    slope = -y / 2.0
-    y_plane = y + slope * (plane_x - (-1.0))
-    plane_point = [plane_x, y_plane]
-    # after refraction, rays miss the focus
-    final = [1.2, 0.25 * y]
-    scenario2.append(np.array([start, plane_point, final]))
-scenario2 = np.array(scenario2)
+scenario2 = compute_snell_paths(n_rays, plane_x=plane_x)
 
 fig, ax = plt.subplots(figsize=(6, 4))
 ax.set_xlim(-1.2, 1.3)

--- a/tests/test_snell.py
+++ b/tests/test_snell.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from aberration_animation import compute_snell_paths
+
+
+def test_angle_changes_only_at_surface():
+    rays = compute_snell_paths(5)
+    # Each ray should consist of start, surface intersection, and final point
+    assert rays.shape[1] == 3
+
+
+def test_snell_law_constant():
+    n1 = 1.0
+    n2 = 1.5
+    rays = compute_snell_paths(7, n1=n1, n2=n2)
+    ratios = []
+    for start, plane, final in rays:
+        theta_in = np.arctan2(plane[1] - start[1], plane[0] - start[0])
+        theta_out = np.arctan2(final[1] - plane[1], final[0] - plane[0])
+        if np.isclose(theta_in, 0.0) and np.isclose(theta_out, 0.0):
+            continue
+        ratios.append(abs(np.sin(theta_in) / np.sin(theta_out)))
+    assert ratios, "No ratios computed"
+    # All ratios should be equal and match the refractive index ratio
+    assert np.allclose(ratios, ratios[0])
+    assert np.isclose(ratios[0], n2 / n1)


### PR DESCRIPTION
## Summary
- add helper `compute_snell_paths` implementing Snell's law for the planar surface
- generate scenario 2 with the helper
- add tests ensuring rays only bend at the surface and that Snell's law holds

## Testing
- `pytest -q`