### PR TITLE
Update ray paths to obey Snell's law

### DIFF
--- a/tests/test_compute_frame.py
+++ b/tests/test_compute_frame.py
@@ -3,41 +3,31 @@ import sys
 import numpy as np
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from aberration_animation import compute_frame, surf_y, scenario1, scenario2
+from aberration_animation import compute_frame, surf_y, ys, plane_x, radius
 
 
 def test_compute_frame_shapes():
-    x, slopes, intercepts = compute_frame(0.5)
+    x, slopes, intercepts, kinks = compute_frame(0.5)
     assert x.shape == surf_y.shape
-    assert slopes.shape[0] == scenario1.shape[0]
-    assert intercepts.shape[0] == scenario1.shape[0]
+    assert slopes.shape[0] == ys.shape[0]
+    assert intercepts.shape[0] == ys.shape[0]
+    assert kinks.shape[0] == ys.shape[0]
 
 
-def test_compute_frame_endpoints():
-    x0, s0, b0 = compute_frame(0.0)
-    x1, s1, b1 = compute_frame(1.0)
-
-    expected_s0 = []
-    expected_b0 = []
-    for row in scenario1:
-        p1 = row[1]
-        p2 = row[2]
-        m = (p2[1] - p1[1]) / (p2[0] - p1[0])
-        b = p1[1] - m * p1[0]
-        expected_s0.append(m)
-        expected_b0.append(b)
-    assert np.allclose(s0, expected_s0)
-    assert np.allclose(b0, expected_b0)
-
-    expected_s1 = []
-    expected_b1 = []
-    for row in scenario2:
-        p1 = row[1]
-        p2 = row[2]
-        m = (p2[1] - p1[1]) / (p2[0] - p1[0])
-        b = p1[1] - m * p1[0]
-        expected_s1.append(m)
-        expected_b1.append(b)
-    assert np.allclose(s1, expected_s1)
-    assert np.allclose(b1, expected_b1)
-
+def test_snells_law_and_kinks():
+    t = 0.3
+    n_ratio = 1.4
+    x, slopes, intercepts, kinks = compute_frame(t, n_ratio=n_ratio)
+    start_angle = np.arcsin(np.clip(0.6 / radius, -1 + 1e-9, 1 - 1e-9))
+    end_angle = np.arcsin(0.6 / 50)
+    angle = (1 - t) * start_angle + t * end_angle
+    r = 0.6 / np.sin(angle)
+    for y, m, kink in zip(ys, slopes, kinks):
+        expected_x = np.sqrt(r**2 - y**2) - r + plane_x
+        assert np.isclose(kink, expected_x)
+        normal_angle = np.arctan2(y, np.sqrt(r**2 - y**2))
+        out_angle = abs(normal_angle - np.arctan(m))
+        if np.sin(abs(normal_angle)) == 0 and out_angle == 0:
+            continue
+        ratio = np.sin(abs(normal_angle)) / np.sin(out_angle)
+        assert np.isclose(ratio, n_ratio)


### PR DESCRIPTION
## Summary
- compute ray intersections on the surface and refracted directions using Snell's law
- draw rays using these new intersections
- test that rays meet the optical surface and satisfy Snell's law

## Testing
- `pytest -q`
