### PR TITLE
Fix Snell ratio sign to focus rays

### DIFF
--- a/aberration_animation.py
+++ b/aberration_animation.py
@@ -106,7 +106,10 @@ def compute_frame(t, n_ratio=1.4):
             normal_angle = 0.0
 
         phi_in = np.abs(normal_angle)
-        phi_out = np.arcsin(np.sin(phi_in) / n_ratio)
+        # multiply by ``n_ratio`` so that ``n_ratio > 1`` focuses the rays
+        phi_out = np.arcsin(
+            np.clip(np.sin(phi_in) * n_ratio, -1 + 1e-9, 1 - 1e-9)
+        )
         orient = normal_angle - np.sign(normal_angle) * phi_out
         m = np.tan(orient)
         b = y - m * x_int

--- a/tests/test_compute_frame.py
+++ b/tests/test_compute_frame.py
@@ -30,4 +30,4 @@ def test_snells_law_and_kinks():
         if np.sin(abs(normal_angle)) == 0 and out_angle == 0:
             continue
         ratio = np.sin(abs(normal_angle)) / np.sin(out_angle)
-        assert np.isclose(ratio, n_ratio)
+        assert np.isclose(ratio, 1 / n_ratio)


### PR DESCRIPTION
## Summary
- correct the refraction ratio so the surface focuses rays
- update tests to the new formula

## Testing
- `pytest -q`