### PR TITLE
Allow overriding plot range via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ useful options are:
 | `--far-radius` | Effective radius when the surface is nearly a plane (default `50`). |
 | `--aperture` | Half height of the optical element and view window (default `0.6`). |
 | `--interval` | Delay between animation frames in milliseconds (default `50`). |
+| `--x-start` | X coordinate where rays originate (default `-1.0`). |
+| `--x-final` | X coordinate where rays terminate (default `1.6`). |
+| `--xlim` | X-axis limits for the plot (default computed from `x-start` and `x-final`). |
 
 For example, to animate with more rays and a slower frame rate run:
 

--- a/aberration_animation.py
+++ b/aberration_animation.py
@@ -52,7 +52,7 @@ x_start = -1.0
 x_final = 1.6
 
 # axis limits and figure size
-xlim = (-1.2, 1.7)
+xlim = (x_start - 0.2, x_final + 0.1)
 ylim = (-aperture, aperture)
 figsize = (6, 4)
 
@@ -348,6 +348,14 @@ if __name__ == "__main__":
     parser.add_argument("--n-ratio", type=float, default=ref_index_ratio, help="refractive index ratio")
     parser.add_argument("--x-start", type=float, default=x_start, help="x coordinate where rays start")
     parser.add_argument("--x-final", type=float, default=x_final, help="x coordinate where rays end")
+    parser.add_argument(
+        "--xlim",
+        type=float,
+        nargs=2,
+        metavar=("XMIN", "XMAX"),
+        default=None,
+        help="x-axis limits for the plot",
+    )
     args = parser.parse_args()
 
     n_rays = args.n_rays
@@ -363,6 +371,10 @@ if __name__ == "__main__":
     ref_index_ratio = args.n_ratio
     x_start = args.x_start
     x_final = args.x_final
+    if args.xlim is None:
+        xlim = (x_start - 0.2, x_final + 0.1)
+    else:
+        xlim = tuple(args.xlim)
 
     incoming_final_angles = np.linspace(max_in_angle, -max_in_angle, n_rays)
     ys = np.linspace(-y_range, y_range, n_rays)


### PR DESCRIPTION
## Summary
- compute axis limits from user options
- expose xlim in command line interface
- document x-start, x-final, and xlim options in README

## Testing
- `pytest -q`