### PR TITLE
Expose CLI options for plane wave animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,8 @@ Run it with:
 ```bash
 python3 plane_wave_animation.py
 ```
+
+Like the main aberration animation script, most parameters can be overridden
+from the command line. Useful options include `--n-rays`, `--frames`,
+`--plane-x`, `--radius`, `--far-radius`, `--aperture`, `--surf-samples`,
+`--interval`, `--n-ratio`, `--x-start` and `--x-final`.

--- a/plane_wave_animation.py
+++ b/plane_wave_animation.py
@@ -127,7 +127,37 @@ class Animator:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Plane wave surface animation")
-    parser.parse_args()
+    parser.add_argument("--n-rays", type=int, default=params.n_rays, help="number of rays")
+    parser.add_argument("--frames", type=int, default=params.frames, help="animation frames")
+    parser.add_argument("--ray-range", type=float, default=params.y_range, help="half range of ray starting y positions")
+    parser.add_argument("--plane-x", type=float, default=params.plane_x, help="x position of the plane at t=1")
+    parser.add_argument("--radius", type=float, default=params.radius, help="initial surface radius")
+    parser.add_argument("--far-radius", type=float, default=params.far_radius, help="effective radius at t=1")
+    parser.add_argument("--aperture", type=float, default=params.aperture, help="half height of the optical element")
+    parser.add_argument("--surf-samples", type=int, default=params.surf_samples, help="number of points for the surface")
+    parser.add_argument("--interval", type=int, default=params.interval, help="animation frame interval (ms)")
+    parser.add_argument("--n-ratio", type=float, default=params.ref_index_ratio, help="refractive index ratio")
+    parser.add_argument("--x-start", type=float, default=params.x_start, help="x coordinate where rays start")
+    parser.add_argument("--x-final", type=float, default=params.x_final, help="x coordinate where rays end")
+    args = parser.parse_args()
+
+    params.n_rays = args.n_rays
+    params.frames = args.frames
+    params.y_range = args.ray_range
+    params.plane_x = args.plane_x
+    params.radius = args.radius
+    params.far_radius = args.far_radius
+    params.aperture = args.aperture
+    params.surf_samples = args.surf_samples
+    params.interval = args.interval
+    params.ref_index_ratio = args.n_ratio
+    params.x_start = args.x_start
+    params.x_final = args.x_final
+
+    params.ys = np.linspace(-params.y_range, params.y_range, params.n_rays)
+    params.surf_y = np.linspace(-params.aperture, params.aperture, params.surf_samples)
+    params.ylim = (-params.aperture, params.aperture)
+
     Animator().run()
 
 


### PR DESCRIPTION
## Summary
- allow custom parameters for `plane_wave_animation` via CLI
- document options in README

## Testing
- `pytest -q`