### PR TITLE
Add virtual ray extensions and focal point

### DIFF
--- a/tests/test_plane_wave_animation.py
+++ b/tests/test_plane_wave_animation.py
@@ -53,6 +53,8 @@ def test_animator_run_and_update(monkeypatch):
     animation = anim.run()
     assert isinstance(animation, FuncAnimation)
     artists = anim._update(0)
-    assert len(artists) == params.n_rays + 2
+    assert len(artists) == params.n_rays * 2 + 5
     for line in anim.lines:
         assert len(line.get_xdata()) == 3
+    for line in anim.ext_lines:
+        assert len(line.get_xdata()) == 2


### PR DESCRIPTION
## Summary
- add dashed continuation of incoming rays in `plane_wave_animation.py`
- compute and mark focal point of those hypothetical rays
- adjust `_update` to return additional artists
- update tests accordingly

## Testing
- `pytest -q`