### PR TITLE
Add frame saving and GIF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ For example, to animate with more rays and a slower frame rate run:
 python3 aberration_animation.py --n-rays 21 --interval 100
 ```
 
+When run outside the test suite, this script also saves the first and last
+frames as `aberration_first.png` and `aberration_last.png`.  In addition the
+entire animation is written to `aberration.gif`. Saving is skipped
+automatically when `pytest` is running.
+
 A second script `plane_wave_animation.py` demonstrates a different scenario. It begins with a plane wave of horizontal rays striking the curved surface and then gradually flattens the interface while keeping the outgoing rays fixed.
 Run it with:
 

--- a/aberration_animation.py
+++ b/aberration_animation.py
@@ -31,6 +31,12 @@ def main() -> None:
         default=params.focal_point,
         help="focal point coordinates as 'x y'",
     )
+    parser.add_argument(
+        "--save-prefix",
+        type=str,
+        default="aberration",
+        help="prefix for saved images (set to '' to disable saving)",
+    )
     args = parser.parse_args()
 
     params.n_rays = args.n_rays
@@ -53,7 +59,9 @@ def main() -> None:
     params.surf_y = np.linspace(-params.aperture, params.aperture, params.surf_samples)
     params.ylim = (-params.aperture, params.aperture)
 
-    animation.run_animation()
+    prefix = args.save_prefix
+    save = bool(prefix)
+    animation.run_animation(save=save, prefix=prefix or "aberration")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support optional saving of first/last frames and a GIF
- expose `--save-prefix` argument in the CLI
- skip saving while tests run
- document saved files in the README

## Testing
- `pytest -q`