### PR TITLE
Add axis line and even ray count check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ useful options are:
 
 | Option | Meaning |
 | ------ | ------- |
-| `--n-rays` | Number of rays traced through the optic (default `11`). |
+| `--n-rays` | Number of rays traced through the optic (default `10`). |
 | `--frames` | Total number of animation frames (default `120`). |
 | `--max-in-angle` | Final incoming angle in radians at the edges of the beam (default `0.3`). |
 | `--plane-x` | X position of the optical interface when it becomes flat (default `0.5`). |
@@ -40,7 +40,7 @@ useful options are:
 For example, to animate with more rays and a slower frame rate run:
 
 ```bash
-python3 aberration_animation.py --n-rays 21 --interval 100
+python3 aberration_animation.py --n-rays 20 --interval 100
 ```
 
 When run outside the test suite, this script also saves the first and last

--- a/aberration/params.py
+++ b/aberration/params.py
@@ -7,7 +7,7 @@ from typing import Tuple
 import numpy as np
 
 # number of rays and animation frames
-n_rays: int = 11
+n_rays: int = 10
 frames: int = 120
 
 # final incoming ray angles at ``t=1``

--- a/aberration/utils.py
+++ b/aberration/utils.py
@@ -33,6 +33,7 @@ def build_patch(x_values: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
 
 def init_axes() -> Tuple[plt.Figure, plt.Axes, Polygon, Polygon]:
     """Return a matplotlib figure, axis and background patches."""
+    assert params.n_rays % 2 == 0, "n_rays must be even"
     fig, ax = plt.subplots(figsize=params.figsize)
     ax.set_xlim(*params.xlim)
     ax.set_ylim(*params.ylim)
@@ -46,5 +47,6 @@ def init_axes() -> Tuple[plt.Figure, plt.Axes, Polygon, Polygon]:
     right_patch = Polygon(right_xy, closed=True, fc="#EFE9DE", ec=None, zorder=0)
     ax.add_patch(left_patch)
     ax.add_patch(right_patch)
+    ax.axhline(0.0, color="black", linestyle="--", lw=1)
 
     return fig, ax, left_patch, right_patch

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 from aberration.utils import build_patch, init_axes
 from aberration import params
@@ -21,4 +22,21 @@ def test_init_axes_returns_objects(monkeypatch):
     assert fig is not None
     assert ax.get_xlim() == params.xlim
     assert left_patch.get_xy().shape[1] == 2
+    found = False
+    for line in ax.lines:
+        if line.get_linestyle() == "--" and line.get_color() == "black":
+            found = True
+            break
+    assert found, "y=0 line not found"
     plt.close(fig)
+
+
+def test_n_rays_must_be_even(monkeypatch):
+    monkeypatch.setattr(plt, "show", lambda: None)
+    original = params.n_rays
+    params.n_rays = 5
+    try:
+        with pytest.raises(AssertionError):
+            init_axes()
+    finally:
+        params.n_rays = original


### PR DESCRIPTION
## Summary
- mark that n-rays must be even by default
- draw a dashed black reference line at `y=0`
- document new default and update example
- test for the new line and parameter restriction

## Testing
- `pytest -q`